### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/qualifiedDCToISO19139v1.0.xslt
+++ b/qualifiedDCToISO19139v1.0.xslt
@@ -399,7 +399,7 @@
                                                   <xsl:when
                                                   test="starts-with(normalize-space(string(.)), 'doi:')">
                                                   <xsl:value-of
-                                                  select="concat('http://dx.doi.org/', substring-after(normalize-space(string(.)), 'doi:'))"
+                                                  select="concat('https://doi.org/', substring-after(normalize-space(string(.)), 'doi:'))"
                                                   />
                                                   </xsl:when>
                                                   <xsl:when


### PR DESCRIPTION
The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) ;-)